### PR TITLE
Change dont use class alias for better compatibility

### DIFF
--- a/disallow-mail.php
+++ b/disallow-mail.php
@@ -10,6 +10,8 @@
  * License:      MIT License
  */
 
+use PHPMailer\PHPMailer\PHPMailer;
+
 (new class {
     /**
      * Class invocation.
@@ -60,14 +62,14 @@
     /**
      * Overwrite phpmailer instance to prevent message sends.
      *
-     * @param  \PHPMailer\PHPMailer\PHPMailer  wp phpmailer instance
+     * @param  PHPMailer  wp phpmailer instance
      * @return void
      */
-    public function disablePHPMailer(\PHPMailer\PHPMailer\PHPMailer $phpmailer): void
+    public function disablePHPMailer(PHPMailer $phpmailer): void
     {
         global $phpmailer;
 
-        $phpmailer = new \PHPMailer\PHPMailer\PHPMailer (true);
+        $phpmailer = new PHPMailer (true);
     }
 
     /**

--- a/disallow-mail.php
+++ b/disallow-mail.php
@@ -60,14 +60,14 @@
     /**
      * Overwrite phpmailer instance to prevent message sends.
      *
-     * @param  PHPMailer wp phpmailer instance
+     * @param  \PHPMailer\PHPMailer\PHPMailer  wp phpmailer instance
      * @return void
      */
-    public function disablePHPMailer(PHPMailer $phpmailer): void
+    public function disablePHPMailer(\PHPMailer\PHPMailer\PHPMailer $phpmailer): void
     {
         global $phpmailer;
 
-        $phpmailer = new PHPMailer(true);
+        $phpmailer = new \PHPMailer\PHPMailer\PHPMailer (true);
     }
 
     /**

--- a/disallow-mail.php
+++ b/disallow-mail.php
@@ -69,7 +69,7 @@ use PHPMailer\PHPMailer\PHPMailer;
     {
         global $phpmailer;
 
-        $phpmailer = new PHPMailer (true);
+        $phpmailer = new PHPMailer(true);
     }
 
     /**


### PR DESCRIPTION
This PR is a simple compatibility fix. In one of my projects the plugin threw an exception. This happened because the `PHPMailer` alias was not set on the target server. 